### PR TITLE
Add radios bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ xcuserdata
 .DS_Store
 *.xcresult
 *.swp
+
+*_BACKUP_*.swift
+*_REMOTE_*.swift
+*_BASE_*.swift
+*_LOCAL_*.swift

--- a/XPTouchBar/DebugView.swift
+++ b/XPTouchBar/DebugView.swift
@@ -21,9 +21,15 @@ struct DebugView: View {
             Entry(dataref: Dataref.TaxiLightOn, value: props.taxiLight),
             Entry(dataref: Dataref.ViewType, value: props.camera),
             Entry(dataref: Dataref.Com1Power, value: props.com1power),
+            Entry(dataref: Dataref.AudioSelectionCom1, value: props.com1audio),
             Entry(dataref: Dataref.Com2Power, value: props.com2power),
+            Entry(dataref: Dataref.AudioSelectionCom2, value: props.com2audio),
             Entry(dataref: Dataref.Nav1Power, value: props.nav1power),
+            Entry(dataref: Dataref.AudioSelectionNav1, value: props.nav1audio),
             Entry(dataref: Dataref.Nav2Power, value: props.nav2power),
+            Entry(dataref: Dataref.AudioSelectionNav2, value: props.nav2audio),
+            Entry(dataref: Dataref.AudioMarkerEnabled, value: props.markerAudio),
+            Entry(dataref: Dataref.AudioComSelection, value: props.comSelection),
             Entry(dataref: Dataref.HideYoke, value: props.hideYoke)
         ].sorted(using: sortOrder)
     }

--- a/XPTouchBar/DebugView.swift
+++ b/XPTouchBar/DebugView.swift
@@ -28,8 +28,8 @@ struct DebugView: View {
             Entry(dataref: Dataref.AudioSelectionNav1, value: props.nav1audio),
             Entry(dataref: Dataref.Nav2Power, value: props.nav2power),
             Entry(dataref: Dataref.AudioSelectionNav2, value: props.nav2audio),
-            Entry(dataref: Dataref.AudioMarkerEnabled, value: props.markerAudio),
             Entry(dataref: Dataref.AudioComSelection, value: props.comSelection),
+            Entry(dataref: Dataref.AudioDmeEnabled, value: props.dmeAudio),
             Entry(dataref: Dataref.HideYoke, value: props.hideYoke)
         ].sorted(using: sortOrder)
     }

--- a/XPTouchBar/Model.swift
+++ b/XPTouchBar/Model.swift
@@ -43,3 +43,9 @@ extension Gear: Toggleable {
         }
     }
 }
+
+/// Which COM audio channel is transmitting
+enum ComSelection {
+    case com1
+    case com2
+}

--- a/XPTouchBar/MyTouchBar.swift
+++ b/XPTouchBar/MyTouchBar.swift
@@ -8,7 +8,7 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
         let touchBar = NSTouchBar()
         touchBar.customizationIdentifier = .xpTouchBar
         touchBar.defaultItemIdentifiers = [.throttle, .mixture, .flaps]
-        touchBar.customizationAllowedItemIdentifiers = [.throttle, .pitch, .mixture, .flaps, .gear, .parkingBrake, .speedbrake, .simSpeed, .lights, .camera]
+        touchBar.customizationAllowedItemIdentifiers = [.throttle, .pitch, .mixture, .flaps, .gear, .parkingBrake, .speedbrake, .simSpeed, .lights, .camera, .radios, .flexibleSpace]
         touchBar.delegate = self
         return touchBar
     }
@@ -117,6 +117,48 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
             // This method will also construct the items of the popover touchbar
             popover.popoverTouchBar.delegate = touchBar.delegate!
             return popover
+        case .radios:
+            let popover = NSPopoverTouchBarItem(identifier: identifier)
+            popover.customizationLabel = "Radios"
+            popover.collapsedRepresentationImage = NSImage(systemSymbolName: "radio", accessibilityDescription: "Radios")
+            popover.popoverTouchBar.customizationIdentifier = .radiosBar
+            popover.popoverTouchBar.defaultItemIdentifiers = [.com1, .com1Mic, .flexibleSpace, .com2, .com2Mic, .flexibleSpace, .nav1, .nav2, .flexibleSpace, .dme, .flexibleSpace, .mkr]
+            popover.popoverTouchBar.delegate = touchBar.delegate!
+            return popover
+        case .com1:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "COM1", target: self, action: #selector(Self.com1Changed(_:)))
+            toggle.customizationLabel = "COM1"
+            return toggle
+        case .com2:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "COM2", target: self, action: #selector(Self.com2Changed(_:)))
+            toggle.customizationLabel = "COM2"
+            return toggle
+        case .nav1:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "NAV1", target: self, action: #selector(Self.nav1Changed(_:)))
+            toggle.customizationLabel = "NAV1"
+            return toggle
+        case .nav2:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "NAV2", target: self, action: #selector(Self.nav2Changed(_:)))
+            toggle.customizationLabel = "NAV2"
+            return toggle
+        case .dme:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "DME", target: self, action: #selector(Self.dmeChanged(_:)))
+            toggle.customizationLabel = "DME"
+            return toggle
+        case .mkr:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "MKR", target: self, action: #selector(Self.mkrChanged(_:)))
+            toggle.customizationLabel = "MKR"
+            return toggle
+        case .com1Mic:
+            let image = NSImage(systemSymbolName: "mic", accessibilityDescription: "COM1 Mic")!
+            let toggle = NSButtonTouchBarItem(identifier: identifier, image: image, target: self, action: #selector(Self.com1MicPressed(_:)))
+            toggle.customizationLabel = "COM1 MIC"
+            return toggle
+        case .com2Mic:
+            let image = NSImage(systemSymbolName: "mic", accessibilityDescription: "COM2 Mic")!
+            let toggle = NSButtonTouchBarItem(identifier: identifier, image: image, target: self, action: #selector(Self.com2MicPressed(_:)))
+            toggle.customizationLabel = "COM2 MIC"
+            return toggle
         case .camera:
             let labels = [
                 "Cockpit",
@@ -222,6 +264,38 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
         props.strobeLights.toggle()
     }
     
+    @objc func com1Changed(_ sender: NSButton) {
+        props.com1audio.toggle()
+    }
+    
+    @objc func com2Changed(_ sender: NSButton) {
+        props.com2audio.toggle()
+    }
+    
+    @objc func nav1Changed(_ sender: NSButton) {
+        props.nav1audio.toggle()
+    }
+    
+    @objc func nav2Changed(_ sender: NSButton) {
+        props.nav2audio.toggle()
+    }
+    
+    @objc func mkrChanged(_ sender: NSButton) {
+        props.markerAudio.toggle()
+    }
+    
+    @objc func dmeChanged(_ sender: NSButton) {
+        props.dmeAudio.toggle()
+    }
+    
+    @objc func com1MicPressed(_ sender: NSButton) {
+        props.comSelection = .com1
+    }
+    
+    @objc func com2MicPressed(_ sender: NSButton) {
+        props.comSelection = .com2
+    }
+    
     func updateNSTouchBar(_ touchBar: NSTouchBar) {
         if let s = touchBar.item(forIdentifier: .speedbrake) as? NSSliderTouchBarItem {
             s.doubleValue = Double(props.speedbrake)
@@ -315,12 +389,60 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
                 taxiButton.bezelColor = lightsBezelColor(props.taxiLight)
             }
         }
+        
+        if let r = touchBar.item(forIdentifier: .radios) as? NSPopoverTouchBarItem {
+            let radiosBar = r.popoverTouchBar
+            
+            if let com1Button = radiosBar.item(forIdentifier: .com1) as? NSButtonTouchBarItem {
+                com1Button.bezelColor = radiosBezelColor(props.com1audio)
+            }
+            
+            if let com2Button = radiosBar.item(forIdentifier: .com2) as? NSButtonTouchBarItem {
+                com2Button.bezelColor = radiosBezelColor(props.com2audio)
+            }
+            
+            if let nav1Button = radiosBar.item(forIdentifier: .nav1) as? NSButtonTouchBarItem {
+                nav1Button.bezelColor = radiosBezelColor(props.nav1audio)
+            }
+            
+            if let nav2Button = radiosBar.item(forIdentifier: .nav2) as? NSButtonTouchBarItem {
+                nav2Button.bezelColor = radiosBezelColor(props.nav2audio)
+            }
+            
+            if let mkrButton = radiosBar.item(forIdentifier: .mkr) as? NSButtonTouchBarItem {
+                mkrButton.bezelColor = radiosBezelColor(props.markerAudio)
+            }
+            
+            if let dmeButton = radiosBar.item(forIdentifier: .dme) as? NSButtonTouchBarItem {
+                dmeButton.bezelColor = radiosBezelColor(props.dmeAudio)
+            }
+            
+            if let com1MicButton = radiosBar.item(forIdentifier: .com1Mic) as? NSButtonTouchBarItem,
+               let com2MicButton = radiosBar.item(forIdentifier: .com2Mic) as? NSButtonTouchBarItem {
+                switch props.comSelection {
+                case .com1:
+                    com1MicButton.bezelColor = .systemGreen
+                    com2MicButton.bezelColor = .controlColor
+                case .com2:
+                    com1MicButton.bezelColor = .controlColor
+                    com2MicButton.bezelColor = .systemGreen
+                }
+            }
+        }
     }
 }
 
 fileprivate func lightsBezelColor(_ isOn: Bool) -> NSColor {
     if isOn {
         return .systemYellow
+    } else {
+        return .controlColor
+    }
+}
+
+fileprivate func radiosBezelColor(_ isOn: Bool) -> NSColor {
+    if isOn {
+        return .systemGreen
     } else {
         return .controlColor
     }

--- a/XPTouchBar/MyTouchBar.swift
+++ b/XPTouchBar/MyTouchBar.swift
@@ -122,7 +122,7 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
             popover.customizationLabel = "Radios"
             popover.collapsedRepresentationImage = NSImage(systemSymbolName: "radio", accessibilityDescription: "Radios")
             popover.popoverTouchBar.customizationIdentifier = .radiosBar
-            popover.popoverTouchBar.defaultItemIdentifiers = [.com1, .com1Mic, .flexibleSpace, .com2, .com2Mic, .flexibleSpace, .nav1, .nav2, .flexibleSpace, .dme, .flexibleSpace, .mkr]
+            popover.popoverTouchBar.defaultItemIdentifiers = [.com1, .com1Mic, .flexibleSpace, .com2, .com2Mic, .flexibleSpace, .nav1, .nav2, .flexibleSpace, .dme]
             popover.popoverTouchBar.delegate = touchBar.delegate!
             return popover
         case .com1:
@@ -145,18 +145,12 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
             let toggle = NSButtonTouchBarItem(identifier: identifier, title: "DME", target: self, action: #selector(Self.dmeChanged(_:)))
             toggle.customizationLabel = "DME"
             return toggle
-        case .mkr:
-            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "MKR", target: self, action: #selector(Self.mkrChanged(_:)))
-            toggle.customizationLabel = "MKR"
-            return toggle
         case .com1Mic:
-            let image = NSImage(systemSymbolName: "mic", accessibilityDescription: "COM1 Mic")!
-            let toggle = NSButtonTouchBarItem(identifier: identifier, image: image, target: self, action: #selector(Self.com1MicPressed(_:)))
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "MIC", target: self, action: #selector(Self.com1MicPressed(_:)))
             toggle.customizationLabel = "COM1 MIC"
             return toggle
         case .com2Mic:
-            let image = NSImage(systemSymbolName: "mic", accessibilityDescription: "COM2 Mic")!
-            let toggle = NSButtonTouchBarItem(identifier: identifier, image: image, target: self, action: #selector(Self.com2MicPressed(_:)))
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "MIC", target: self, action: #selector(Self.com2MicPressed(_:)))
             toggle.customizationLabel = "COM2 MIC"
             return toggle
         case .camera:
@@ -165,9 +159,9 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
                 "Chase",
                 "Circle",
                 "HUD",
-                "Linear Spot",
+                "Linear",
                 "Runway",
-                "Still Spot",
+                "Spot",
                 "Tower",
             ]
             let control = NSPickerTouchBarItem(identifier: identifier, labels: labels, selectionMode: .selectOne, target: self, action: #selector(Self.cameraChanged(_:)))
@@ -278,10 +272,6 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
     
     @objc func nav2Changed(_ sender: NSButton) {
         props.nav2audio.toggle()
-    }
-    
-    @objc func mkrChanged(_ sender: NSButton) {
-        props.markerAudio.toggle()
     }
     
     @objc func dmeChanged(_ sender: NSButton) {
@@ -407,10 +397,6 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
             
             if let nav2Button = radiosBar.item(forIdentifier: .nav2) as? NSButtonTouchBarItem {
                 nav2Button.bezelColor = radiosBezelColor(props.nav2audio)
-            }
-            
-            if let mkrButton = radiosBar.item(forIdentifier: .mkr) as? NSButtonTouchBarItem {
-                mkrButton.bezelColor = radiosBezelColor(props.markerAudio)
             }
             
             if let dmeButton = radiosBar.item(forIdentifier: .dme) as? NSButtonTouchBarItem {

--- a/XPTouchBar/TouchBarIdentifiers.swift
+++ b/XPTouchBar/TouchBarIdentifiers.swift
@@ -22,7 +22,6 @@ extension NSTouchBarItem.Identifier {
     static let nav1 = NSTouchBarItem.Identifier("XPTouchBar.Radios.NAV1")
     static let nav2 = NSTouchBarItem.Identifier("XPTouchBar.Radios.NAV2")
     static let dme = NSTouchBarItem.Identifier("XPTouchBar.Radios.DME")
-    static let mkr = NSTouchBarItem.Identifier("XPTouchBar.Radios.MKR")
     static let com1Mic = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM1Mic")
     static let com2Mic = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM2Mic")
 }

--- a/XPTouchBar/TouchBarIdentifiers.swift
+++ b/XPTouchBar/TouchBarIdentifiers.swift
@@ -16,9 +16,19 @@ extension NSTouchBarItem.Identifier {
     static let navigationLights = NSTouchBarItem.Identifier("XPTouchBar.Lights.Navigation")
     static let strobeLights = NSTouchBarItem.Identifier("XPTouchBar.Lights.Strobe")
     static let camera = NSTouchBarItem.Identifier("XPTouchBar.Camera")
+    static let radios = NSTouchBarItem.Identifier("XPTouchBar.Radios")
+    static let com1 = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM1")
+    static let com2 = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM2")
+    static let nav1 = NSTouchBarItem.Identifier("XPTouchBar.Radios.NAV1")
+    static let nav2 = NSTouchBarItem.Identifier("XPTouchBar.Radios.NAV2")
+    static let dme = NSTouchBarItem.Identifier("XPTouchBar.Radios.DME")
+    static let mkr = NSTouchBarItem.Identifier("XPTouchBar.Radios.MKR")
+    static let com1Mic = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM1Mic")
+    static let com2Mic = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM2Mic")
 }
 
 extension NSTouchBar.CustomizationIdentifier {
     static let xpTouchBar = NSTouchBar.CustomizationIdentifier("XPTouchBar")
     static let lightsBar = NSTouchBar.CustomizationIdentifier("XPTouchBar.Lights")
+    static let radiosBar = NSTouchBar.CustomizationIdentifier("XPTouchBar.Radios")
 }

--- a/XPTouchBar/XPTouchBarApp.swift
+++ b/XPTouchBar/XPTouchBarApp.swift
@@ -7,6 +7,26 @@ struct XPTouchBarApp: App {
     
     @ObservedObject var props = XPlaneConnector()
     
+    private var com1Mic: Binding<Bool> {
+        Binding<Bool>(
+            get: {
+                return self.props.comSelection == .com1
+            },
+            set: { _ in
+                self.props.comSelection = .com1
+            })
+    }
+    
+    private var com2Mic: Binding<Bool> {
+        Binding<Bool>(
+            get: {
+                return self.props.comSelection == .com2
+            },
+            set: { _ in
+                self.props.comSelection = .com2
+            })
+    }
+    
     init() {
         appDelegate.props = props
     }
@@ -58,6 +78,27 @@ struct XPTouchBarApp: App {
         .onChange(of: props.camera) { newState in
             appDelegate.updateTouchBar()
         }
+        .onChange(of: props.com1audio) { newState in
+            appDelegate.updateTouchBar()
+        }
+        .onChange(of: props.com2audio) { newState in
+            appDelegate.updateTouchBar()
+        }
+        .onChange(of: props.nav1audio) { newState in
+            appDelegate.updateTouchBar()
+        }
+        .onChange(of: props.nav2audio) { newState in
+            appDelegate.updateTouchBar()
+        }
+        .onChange(of: props.markerAudio) { newState in
+            appDelegate.updateTouchBar()
+        }
+        .onChange(of: props.dmeAudio) { newState in
+            appDelegate.updateTouchBar()
+        }
+        .onChange(of: props.comSelection) { newState in
+            appDelegate.updateTouchBar()
+        }
         .windowToolbarStyle(.unifiedCompact(showsTitle: false))
         .commands {
             // Turn off the "New Window" option
@@ -87,31 +128,11 @@ struct XPTouchBarApp: App {
                 }
                 .keyboardShortcut("Y", modifiers: [])
                 
-                Picker("Camera", selection: $props.camera) {
-                    Text("Cockpit").tag(Camera.cockpit)
-                    Text("Chase").tag(Camera.chase)
-                    Text("Circle").tag(Camera.circle)
-                    Text("Forward with HUD").tag(Camera.hud)
-                    Text("Linear Spot").tag(Camera.linearSpot)
-                    Text("Runway").tag(Camera.runway)
-                    Text("Still Spot").tag(Camera.stillSpot)
-                    Text("Tower").tag(Camera.tower)
-                }
+                camera
                 
-                Menu("Radios") {
-                    Toggle("COM1 Power", isOn: $props.com1power)
-                    Toggle("COM2 Power", isOn: $props.com2power)
-                    Toggle("NAV1 Power", isOn: $props.nav1power)
-                    Toggle("NAV2 Power", isOn: $props.nav2power)
-                }
+                lights
                 
-                Menu("Lights") {
-                    Toggle("Beacon", isOn: $props.beaconLights)
-                    Toggle("Landing", isOn: $props.landingLights)
-                    Toggle("Nav", isOn: $props.navigationLights)
-                    Toggle("Strobe", isOn: $props.strobeLights)
-                    Toggle("Taxi", isOn: $props.taxiLight)
-                }
+                radios
             }
         }
         
@@ -119,6 +140,86 @@ struct XPTouchBarApp: App {
             ConnectionView()
                 .environmentObject(props)
                 .padding()
+        }
+    }
+    
+    var camera: some View {
+        Picker("Camera", selection: $props.camera) {
+            Text("Cockpit").tag(Camera.cockpit)
+            Text("Chase").tag(Camera.chase)
+            Text("Circle").tag(Camera.circle)
+            Text("Forward with HUD").tag(Camera.hud)
+            Text("Linear Spot").tag(Camera.linearSpot)
+            Text("Runway").tag(Camera.runway)
+            Text("Still Spot").tag(Camera.stillSpot)
+            Text("Tower").tag(Camera.tower)
+        }
+    }
+    
+    var com1radios: some View {
+        Group {
+            Toggle("COM1 Power", isOn: $props.com1power)
+            Toggle("COM1 Audio", isOn: $props.com1audio)
+            Toggle("COM1 Mic", isOn: com1Mic)
+        }
+    }
+    
+    var com2radios: some View {
+        Group {
+            Toggle("COM2 Power", isOn: $props.com2power)
+            Toggle("COM2 Audio", isOn: $props.com2audio)
+            Toggle("COM2 Mic", isOn: com2Mic)
+        }
+    }
+    
+    var nav1radios: some View {
+        Group {
+            Toggle("NAV1 Power", isOn: $props.nav1power)
+            Toggle("NAV1 Audio", isOn: $props.nav1audio)
+        }
+    }
+    
+    var nav2radios: some View {
+        Group {
+            Toggle("NAV2 Power", isOn: $props.nav2power)
+            Toggle("NAV2 Audio", isOn: $props.nav2audio)
+        }
+    }
+    
+    var comRadios: some View {
+        Group {
+            com1radios
+            Divider()
+            com2radios
+        }
+    }
+    
+    var navRadios: some View {
+        Group {
+            nav1radios
+            Divider()
+            nav2radios
+        }
+    }
+    
+    var radios: some View {
+        Menu("Radios") {
+            comRadios
+            Divider()
+            navRadios
+            Divider()
+            Toggle("DME", isOn: $props.dmeAudio)
+            Toggle("MKR", isOn: $props.markerAudio)
+        }
+    }
+    
+    var lights: some View {
+        Menu("Lights") {
+            Toggle("Beacon", isOn: $props.beaconLights)
+            Toggle("Landing", isOn: $props.landingLights)
+            Toggle("Nav", isOn: $props.navigationLights)
+            Toggle("Strobe", isOn: $props.strobeLights)
+            Toggle("Taxi", isOn: $props.taxiLight)
         }
     }
 }

--- a/XPTouchBar/XPTouchBarApp.swift
+++ b/XPTouchBar/XPTouchBarApp.swift
@@ -90,9 +90,6 @@ struct XPTouchBarApp: App {
         .onChange(of: props.nav2audio) { newState in
             appDelegate.updateTouchBar()
         }
-        .onChange(of: props.markerAudio) { newState in
-            appDelegate.updateTouchBar()
-        }
         .onChange(of: props.dmeAudio) { newState in
             appDelegate.updateTouchBar()
         }
@@ -128,11 +125,52 @@ struct XPTouchBarApp: App {
                 }
                 .keyboardShortcut("Y", modifiers: [])
                 
-                camera
-                
                 lights
                 
                 radios
+            }
+            
+            CommandMenu("Camera") {
+                
+                Button("Cockpit") {
+                    self.props.camera = .cockpit
+                }
+                .keyboardShortcut("9", modifiers: [.shift])
+                
+                Button("Chase") {
+                    self.props.camera = .chase
+                }
+                .keyboardShortcut("8", modifiers: [.shift])
+                
+                Button("Circle") {
+                    self.props.camera = .circle
+                }
+                .keyboardShortcut("4", modifiers: [.shift])
+                
+                Button("Forward with HUD") {
+                    self.props.camera = .hud
+                }
+                .keyboardShortcut("W", modifiers: [.shift])
+                
+                Button("Linear Spot") {
+                    self.props.camera = .linearSpot
+                }
+                .keyboardShortcut("1", modifiers: [.shift])
+                
+                Button("Runway") {
+                    self.props.camera = .runway
+                }
+                .keyboardShortcut("3", modifiers: [.shift])
+                
+                Button("Still Spot") {
+                    self.props.camera = .stillSpot
+                }
+                .keyboardShortcut("2", modifiers: [.shift])
+                
+                Button("Tower") {
+                    self.props.camera = .tower
+                }
+                .keyboardShortcut("5", modifiers: [.shift])
             }
         }
         
@@ -140,19 +178,6 @@ struct XPTouchBarApp: App {
             ConnectionView()
                 .environmentObject(props)
                 .padding()
-        }
-    }
-    
-    var camera: some View {
-        Picker("Camera", selection: $props.camera) {
-            Text("Cockpit").tag(Camera.cockpit)
-            Text("Chase").tag(Camera.chase)
-            Text("Circle").tag(Camera.circle)
-            Text("Forward with HUD").tag(Camera.hud)
-            Text("Linear Spot").tag(Camera.linearSpot)
-            Text("Runway").tag(Camera.runway)
-            Text("Still Spot").tag(Camera.stillSpot)
-            Text("Tower").tag(Camera.tower)
         }
     }
     
@@ -209,7 +234,6 @@ struct XPTouchBarApp: App {
             navRadios
             Divider()
             Toggle("DME", isOn: $props.dmeAudio)
-            Toggle("MKR", isOn: $props.markerAudio)
         }
     }
     

--- a/XPTouchBar/XPlaneConnector/Dataref.swift
+++ b/XPTouchBar/XPlaneConnector/Dataref.swift
@@ -99,6 +99,26 @@ enum Dataref {
     
     /// Nav radio 2 off or on, 0 or 1.
     case Nav2Power
+    
+    /// is com1 selected for listening
+    case AudioSelectionCom1
+    
+    /// is com2 selected for listening
+    case AudioSelectionCom2
+    
+    /// is nav1 selected for listening
+    case AudioSelectionNav1
+    
+    /// is nav2 selected for listening
+    case AudioSelectionNav2
+    
+    /// Is audio for the marker beacons enabled?
+    case AudioMarkerEnabled
+    
+    /// Is DME audio enabled? This only listens to the dedicated DME receiver
+    case AudioDmeEnabled
+    
+    case AudioComSelection
 }
 
 extension Dataref: CustomStringConvertible {
@@ -143,6 +163,20 @@ extension Dataref: CustomStringConvertible {
             return "sim/cockpit2/radios/actuators/nav1_power"
         case .Nav2Power:
             return "sim/cockpit2/radios/actuators/nav2_power"
+        case .AudioSelectionCom1:
+            return "sim/cockpit2/radios/actuators/audio_selection_com1"
+        case .AudioSelectionCom2:
+            return "sim/cockpit2/radios/actuators/audio_selection_com2"
+        case .AudioSelectionNav1:
+            return "sim/cockpit2/radios/actuators/audio_selection_nav1"
+        case .AudioSelectionNav2:
+            return "sim/cockpit2/radios/actuators/audio_selection_nav2"
+        case .AudioMarkerEnabled:
+            return "sim/cockpit2/radios/actuators/audio_marker_enabled"
+        case .AudioDmeEnabled:
+            return "sim/cockpit2/radios/actuators/audio_dme_enabled"
+        case .AudioComSelection:
+            return "sim/cockpit2/radios/actuators/audio_com_selection"
         }
     }
 }

--- a/XPTouchBar/XPlaneConnector/Dataref.swift
+++ b/XPTouchBar/XPlaneConnector/Dataref.swift
@@ -112,9 +112,6 @@ enum Dataref {
     /// is nav2 selected for listening
     case AudioSelectionNav2
     
-    /// Is audio for the marker beacons enabled?
-    case AudioMarkerEnabled
-    
     /// Is DME audio enabled? This only listens to the dedicated DME receiver
     case AudioDmeEnabled
     
@@ -171,8 +168,6 @@ extension Dataref: CustomStringConvertible {
             return "sim/cockpit2/radios/actuators/audio_selection_nav1"
         case .AudioSelectionNav2:
             return "sim/cockpit2/radios/actuators/audio_selection_nav2"
-        case .AudioMarkerEnabled:
-            return "sim/cockpit2/radios/actuators/audio_marker_enabled"
         case .AudioDmeEnabled:
             return "sim/cockpit2/radios/actuators/audio_dme_enabled"
         case .AudioComSelection:

--- a/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
+++ b/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
@@ -157,13 +157,6 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
-    @Published var markerAudio: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .AudioMarkerEnabled, value: markerAudio.floatValue)
-            self.send(dref)
-        }
-    }
-    
     @Published var dmeAudio: Bool = false {
         didSet {
             let dref = DREF(dataref: .AudioDmeEnabled, value: dmeAudio.floatValue)
@@ -322,12 +315,10 @@ fileprivate extension Dataref {
             return 22
         case .AudioSelectionNav2:
             return 23
-        case .AudioMarkerEnabled:
-            return 24
         case .AudioDmeEnabled:
-            return 25
+            return 24
         case .AudioComSelection:
-            return 26
+            return 25
         }
     }
 }
@@ -374,8 +365,6 @@ extension ComSelection: CustomFloatConvertible {
             return 7
         }
     }
-    
-    
 }
 
 extension Camera: CustomFloatConvertible {

--- a/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
+++ b/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
@@ -108,9 +108,23 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
+    @Published var com1audio: Bool = true {
+        didSet {
+            let dref = DREF(dataref: .AudioSelectionCom1, value: com1audio.floatValue)
+            self.send(dref)
+        }
+    }
+    
     @Published var com2power: Bool = true {
         didSet {
             let dref = DREF(dataref: .Com2Power, value: com2power.floatValue)
+            self.send(dref)
+        }
+    }
+    
+    @Published var com2audio: Bool = false {
+        didSet {
+            let dref = DREF(dataref: .AudioSelectionCom2, value: com2audio.floatValue)
             self.send(dref)
         }
     }
@@ -122,9 +136,54 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
+    @Published var nav1audio: Bool = false {
+        didSet {
+            let dref = DREF(dataref: .AudioSelectionNav1, value: nav1audio.floatValue)
+            self.send(dref)
+        }
+    }
+    
     @Published var nav2power: Bool = true {
         didSet {
             let dref = DREF(dataref: .Nav2Power, value: nav2power.floatValue)
+            self.send(dref)
+        }
+    }
+    
+    @Published var nav2audio: Bool = false {
+        didSet {
+            let dref = DREF(dataref: .AudioSelectionNav2, value: nav2audio.floatValue)
+            self.send(dref)
+        }
+    }
+    
+    @Published var markerAudio: Bool = true {
+        didSet {
+            let dref = DREF(dataref: .AudioMarkerEnabled, value: markerAudio.floatValue)
+            self.send(dref)
+        }
+    }
+    
+    @Published var dmeAudio: Bool = false {
+        didSet {
+            let dref = DREF(dataref: .AudioDmeEnabled, value: dmeAudio.floatValue)
+            self.send(dref)
+        }
+    }
+    
+    @Published var comSelection: ComSelection = .com1 {
+        didSet {
+            // Set the corresponding COM receive button states
+            switch comSelection {
+            case .com1:
+                self.com1audio = true
+                self.com2audio = false
+            case .com2:
+                self.com1audio = false
+                self.com2audio = true
+            }
+            
+            let dref = DREF(dataref: .AudioComSelection, value: comSelection.floatValue)
             self.send(dref)
         }
     }
@@ -255,6 +314,20 @@ fileprivate extension Dataref {
             return 18
         case .Nav2Power:
             return 19
+        case .AudioSelectionCom1:
+            return 20
+        case .AudioSelectionCom2:
+            return 21
+        case .AudioSelectionNav1:
+            return 22
+        case .AudioSelectionNav2:
+            return 23
+        case .AudioMarkerEnabled:
+            return 24
+        case .AudioDmeEnabled:
+            return 25
+        case .AudioComSelection:
+            return 26
         }
     }
 }
@@ -290,6 +363,19 @@ extension Gear: CustomFloatConvertible {
             return 1
         }
     }
+}
+
+extension ComSelection: CustomFloatConvertible {
+    var floatValue: Float {
+        switch self {
+        case .com1:
+            return 6
+        case .com2:
+            return 7
+        }
+    }
+    
+    
 }
 
 extension Camera: CustomFloatConvertible {

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,17 +66,24 @@ XPTouchBar has Touch Bar widgets for the following aircraft controls:
   - NAV1 (audio)
   - NAV2 (audio)
   - DME (audio)
-  - MKR (audio)
   
 XPTouchBar also forwards the following X-Plane keyboard shortcuts for convenience:
 
-| Key | Shortcut             |
-|-----|----------------------|
-| B   | Parking Brake On/Off |
-| G   | Landing Gear Up/Down |
-| M   | Show/Hide Map        |
-| P   | Play/Pause           |
-| Y   | Show/Hide Yoke       |
+| Key | Shortcut                 |
+|-----|--------------------------|
+| B   | Parking Brake On/Off     |
+| G   | Landing Gear Up/Down     |
+| M   | Show/Hide Map            |
+| P   | Play/Pause               |
+| Y   | Show/Hide Yoke           |
+| ⇧1  | Linear Spot              |
+| ⇧2  | Still Spot               |
+| ⇧3  | Camera: Runway           |
+| ⇧4  | Camera: Circle           |
+| ⇧5  | Camera: Tower            |
+| ⇧8  | Camera: Chase            |
+| ⇧9  | Camera: 3D Cockpit       |
+| ⇧W  | Camera: Forward With HUD |
 
 ## Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,13 @@ XPTouchBar has Touch Bar widgets for the following aircraft controls:
   - Nav
   - Strobe
   - Taxi
+- Radios
+  - COM1 (audio, mic)
+  - COM2 (audio, mic)
+  - NAV1 (audio)
+  - NAV2 (audio)
+  - DME (audio)
+  - MKR (audio)
   
 XPTouchBar also forwards the following X-Plane keyboard shortcuts for convenience:
 


### PR DESCRIPTION
Add popover bar with radio controls.

Due to space limits, these will be simple audio on/off controls for the most commonly used radios (COM 1+2, NAV 1+2, and any others we have space for).