### PR TITLE
Add autopilot controls

### DIFF
--- a/XPTouchBar/MyTouchBar.swift
+++ b/XPTouchBar/MyTouchBar.swift
@@ -222,7 +222,7 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
             let items = [hdg, nav, apr, rev, alt, vs, vsDown, vsUp]
             
             let group = NSGroupTouchBarItem(identifier: identifier, items: items)
-            group.customizationLabel = "Autopilot (S-TEC 55)"
+            group.customizationLabel = "Autopilot"
             return group
         default:
             return nil

--- a/XPTouchBar/MyTouchBar.swift
+++ b/XPTouchBar/MyTouchBar.swift
@@ -8,7 +8,7 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
         let touchBar = NSTouchBar()
         touchBar.customizationIdentifier = .xpTouchBar
         touchBar.defaultItemIdentifiers = [.throttle, .mixture, .flaps]
-        touchBar.customizationAllowedItemIdentifiers = [.throttle, .pitch, .mixture, .flaps, .gear, .parkingBrake, .speedbrake, .simSpeed, .lights, .camera, .radios, .flexibleSpace]
+        touchBar.customizationAllowedItemIdentifiers = [.throttle, .pitch, .mixture, .flaps, .gear, .parkingBrake, .speedbrake, .simSpeed, .lights, .camera, .radios, .stec55, .flexibleSpace]
         touchBar.delegate = self
         return touchBar
     }
@@ -169,6 +169,57 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
             control.customizationLabel = "Camera"
             control.collapsedRepresentationImage = NSImage(systemSymbolName: "video", accessibilityDescription: "Camera")
             return control
+        case .hdg:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "HDG", target: self, action: #selector(Self.hdgPressed(_:)))
+            toggle.customizationLabel = "Heading Mode"
+            return toggle
+        case .nav:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "NAV", target: self, action: #selector(Self.navPressed(_:)))
+            toggle.customizationLabel = "Navigation Mode"
+            return toggle
+        case .apr:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "APR", target: self, action: #selector(Self.aprPressed(_:)))
+            toggle.customizationLabel = "Approach Mode"
+            return toggle
+        case .rev:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "REV", target: self, action: #selector(Self.revPressed(_:)))
+            toggle.customizationLabel = "Reverse Mode"
+            return toggle
+        case .alt:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "ALT", target: self, action: #selector(Self.altPressed(_:)))
+            toggle.customizationLabel = "Altitude Mode"
+            return toggle
+        case .vs:
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "VS", target: self, action: #selector(Self.vsPressed(_:)))
+            toggle.customizationLabel = "Vertical Speed Mode"
+            return toggle
+        case .vsDown:
+            let image = NSImage(systemSymbolName: "minus", accessibilityDescription: nil)!
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "VS", image: image, target: self, action: #selector(Self.vsDownPressed(_:)))
+            toggle.customizationLabel = "Vertical Speed Down"
+            toggle.bezelColor = .systemGray
+            return repeaterButton(toggle)
+        case .vsUp:
+            let image = NSImage(systemSymbolName: "plus", accessibilityDescription: nil)!
+            let toggle = NSButtonTouchBarItem(identifier: identifier, title: "VS", image: image, target: self, action: #selector(Self.vsUpPressed(_:)))
+            toggle.customizationLabel = "Vertical Speed Up"
+            toggle.bezelColor = .systemGray
+            return repeaterButton(toggle)
+        case .stec55:
+            let hdg = self.touchBar(touchBar, makeItemForIdentifier: .hdg)!
+            let nav = self.touchBar(touchBar, makeItemForIdentifier: .nav)!
+            let apr = self.touchBar(touchBar, makeItemForIdentifier: .apr)!
+            let rev = self.touchBar(touchBar, makeItemForIdentifier: .rev)!
+            let alt = self.touchBar(touchBar, makeItemForIdentifier: .alt)!
+            let vs = self.touchBar(touchBar, makeItemForIdentifier: .vs)!
+            let vsDown = self.touchBar(touchBar, makeItemForIdentifier: .vsDown)!
+            let vsUp = self.touchBar(touchBar, makeItemForIdentifier: .vsUp)!
+            
+            let items = [hdg, nav, apr, rev, alt, vs, vsDown, vsUp]
+            
+            let group = NSGroupTouchBarItem(identifier: identifier, items: items)
+            group.customizationLabel = "Autopilot (S-TEC 55)"
+            return group
         default:
             return nil
         }
@@ -284,6 +335,38 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
     
     @objc func com2MicPressed(_ sender: NSButton) {
         props.comSelection = .com2
+    }
+    
+    @objc func altPressed(_ sender: NSButton) {
+        props.autopilotAltitudeHold()
+    }
+    
+    @objc func hdgPressed(_ sender: NSButton) {
+        props.autopilotHeadingHold()
+    }
+    
+    @objc func aprPressed(_ sender: NSButton) {
+        props.autopilotApproach()
+    }
+    
+    @objc func revPressed(_ sender: NSButton) {
+        props.autopilotBackCourse()
+    }
+    
+    @objc func navPressed(_ sender: NSButton) {
+        props.autopilotNav()
+    }
+    
+    @objc func vsPressed(_ sender: NSButton) {
+        props.autopilotVerticalSpeed()
+    }
+    
+    @objc func vsDownPressed(_ sender: NSButton) {
+        props.autopilotVerticalSpeedDown()
+    }
+    
+    @objc func vsUpPressed(_ sender: NSButton) {
+        props.autopilotVerticalSpeedUp()
     }
     
     func updateNSTouchBar(_ touchBar: NSTouchBar) {
@@ -432,4 +515,12 @@ fileprivate func radiosBezelColor(_ isOn: Bool) -> NSColor {
     } else {
         return .controlColor
     }
+}
+
+fileprivate func repeaterButton(_ button: NSButtonTouchBarItem) -> NSButtonTouchBarItem {
+    if let b = button.view as? NSButton {
+        b.isContinuous = true
+        b.setPeriodicDelay(0.2, interval: 0.15)
+    }
+    return button
 }

--- a/XPTouchBar/TouchBarIdentifiers.swift
+++ b/XPTouchBar/TouchBarIdentifiers.swift
@@ -24,6 +24,15 @@ extension NSTouchBarItem.Identifier {
     static let dme = NSTouchBarItem.Identifier("XPTouchBar.Radios.DME")
     static let com1Mic = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM1Mic")
     static let com2Mic = NSTouchBarItem.Identifier("XPTouchBar.Radios.COM2Mic")
+    static let hdg = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.Heading")
+    static let nav = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.Navigation")
+    static let apr = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.Approach")
+    static let rev = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.Reverse")
+    static let alt = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.Altitude")
+    static let vs = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.VerticalSpeed")
+    static let vsDown = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.VerticalSpeed.Down")
+    static let vsUp = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.VerticalSpeed.Up")
+    static let stec55 = NSTouchBarItem.Identifier("XPTouchBar.Autopilot.S-TEC")
 }
 
 extension NSTouchBar.CustomizationIdentifier {

--- a/XPTouchBar/XPTouchBarApp.swift
+++ b/XPTouchBar/XPTouchBarApp.swift
@@ -125,6 +125,8 @@ struct XPTouchBarApp: App {
                 }
                 .keyboardShortcut("Y", modifiers: [])
                 
+                autopilot
+                
                 lights
                 
                 radios
@@ -224,6 +226,36 @@ struct XPTouchBarApp: App {
             nav1radios
             Divider()
             nav2radios
+        }
+    }
+    
+    var autopilot: some View {
+        Menu("Autopilot") {
+            Button("Altitude Mode (ALT)") {
+                self.props.autopilotAltitudeHold()
+            }
+            Button("Approach Mode (APR)") {
+                self.props.autopilotApproach()
+            }
+            Button("Heading Mode (HDG)") {
+                self.props.autopilotHeadingHold()
+            }
+            Button("Navigation Mode (NAV)") {
+                self.props.autopilotNav()
+            }
+            Button("Reverse Mode (REV)") {
+                self.props.autopilotBackCourse()
+            }
+            Divider()
+            Button("Vertical Speed Mode (VS)") {
+                self.props.autopilotVerticalSpeed()
+            }
+            Button("Vertical Speed Down (-VS)") {
+                self.props.autopilotVerticalSpeedDown()
+            }
+            Button("Vertical Speed Up (+VS)") {
+                self.props.autopilotVerticalSpeedUp()
+            }
         }
     }
     

--- a/XPTouchBar/XPlaneConnector/Command.swift
+++ b/XPTouchBar/XPlaneConnector/Command.swift
@@ -4,6 +4,27 @@ import Foundation
 enum Command {
     /// Toggle the map window
     case MapShowCurrent
+    
+    /// Autopilot altitude select or hold.
+    case AutopilotAltitudeHold
+    
+    /// Autopilot heading-hold.
+    case AutopilotHeadingHold
+    
+    case AutopilotApproach
+    
+    case AutopilotBackCourse
+    
+    case AutopilotNav
+    
+    /// Autopilot vertical speed, at current VSI.
+    case AutopilotVerticalSpeed
+    
+    /// Autopilot VVI down.
+    case AutopilotVerticalSpeedDown
+    
+    /// Autopilot VVI up.
+    case AutopilotVerticalSpeedUp
 }
 
 extension Command: CustomStringConvertible {
@@ -11,6 +32,22 @@ extension Command: CustomStringConvertible {
         switch self {
         case .MapShowCurrent:
             return "sim/map/show_current"
+        case .AutopilotAltitudeHold:
+            return "sim/autopilot/altitude_hold"
+        case .AutopilotHeadingHold:
+            return "sim/autopilot/heading"
+        case .AutopilotApproach:
+            return "sim/autopilot/approach"
+        case .AutopilotBackCourse:
+            return "sim/autopilot/back_course"
+        case .AutopilotNav:
+            return "sim/autopilot/NAV"
+        case .AutopilotVerticalSpeed:
+            return "sim/autopilot/vertical_speed"
+        case .AutopilotVerticalSpeedDown:
+            return "sim/autopilot/vertical_speed_down"
+        case .AutopilotVerticalSpeedUp:
+            return "sim/autopilot/vertical_speed_up"
         }
     }
 }

--- a/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
+++ b/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
@@ -241,6 +241,46 @@ class XPlaneConnector: ObservableObject {
         self.send(cmnd)
     }
     
+    func autopilotAltitudeHold() {
+        let cmd = CMND(command: .AutopilotAltitudeHold)
+        self.send(cmd)
+    }
+    
+    func autopilotHeadingHold() {
+        let cmd = CMND(command: .AutopilotHeadingHold)
+        self.send(cmd)
+    }
+    
+    func autopilotApproach() {
+        let cmd = CMND(command: .AutopilotApproach)
+        self.send(cmd)
+    }
+    
+    func autopilotBackCourse() {
+        let cmd = CMND(command: .AutopilotBackCourse)
+        self.send(cmd)
+    }
+    
+    func autopilotNav() {
+        let cmd = CMND(command: .AutopilotNav)
+        self.send(cmd)
+    }
+    
+    func autopilotVerticalSpeed() {
+        let cmd = CMND(command: .AutopilotVerticalSpeed)
+        self.send(cmd)
+    }
+    
+    func autopilotVerticalSpeedDown() {
+        let cmd = CMND(command: .AutopilotVerticalSpeedDown)
+        self.send(cmd)
+    }
+    
+    func autopilotVerticalSpeedUp() {
+        let cmd = CMND(command: .AutopilotVerticalSpeedUp)
+        self.send(cmd)
+    }
+    
     private func restart() {
         stop()
         start()

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,14 @@ Control [X-Plane](https://www.x-plane.com) with the Mac Touch Bar.
 
 XPTouchBar is a companion app to X-Plane which presents flight controls in the Touch Bar.
 
-XPTouchBar is completely customizable. You choose the controls that appear in the Touch Bar to complement the aircraft you're flying, and the hardware controls you have (e.g. sidestick/yoke, rudder pedals, throttle quadrant).
+XPTouchBar is completely customizable. You choose the controls that appear in the Touch Bar to complement the aircraft you're flying, and the hardware controls you have. (For example, if you don't have a throttle quadrant, put the throttle controls in the Touch Bar. If you do have a throttle quadrant, use the Touch Bar for something else).
 
 You could use XPTouchBar as...
 
 - a throttle quadrant (Throttle / Prop / Mixture / Speedbrake / Flaps as needed)
 - an avionics panel
 - an audio panel
+- an autopilot unit
 - ...anything else you can think of
 
 ![Screenshot](img/jet.png)
@@ -32,6 +33,8 @@ XPTouchBar aims to provide X-Plane controls which:
 - play to the strengths of the Touch Bar (e.g. sliders and multi-state switches)
 - are used frequently in flight, or must be quickly accessible during takeoff/landing
 - are hard to use with the keyboard or mouse
+
+The placement and priority of controls in XPTouchBar follows the adage "Aviate, Navigate, Communicate". For example, the throttle quadrant is an "Aviate" control, so it is immediately accessible at the top level of the Touch Bar. Meanwhile the audio panel is a "Communicate" control, so it lives in a popover.
 
 ## Features
 
@@ -69,6 +72,13 @@ XPTouchBar has Touch Bar widgets for the following aircraft controls:
   - NAV1 (audio)
   - NAV2 (audio)
   - DME (audio)
+- Autopilot (S-TEC 55)
+  - HDG
+  - NAV
+  - APR
+  - REV
+  - ALT
+  - VS (with +VS/-VS controls, press-and-hold them to change vertical speed quickly)
   
 XPTouchBar also forwards the following X-Plane keyboard shortcuts for convenience:
 
@@ -88,10 +98,12 @@ XPTouchBar also forwards the following X-Plane keyboard shortcuts for convenienc
 | ⇧9  | Camera: 3D Cockpit       |
 | ⇧W  | Camera: Forward With HUD |
 
+**Note:** For simplicity, only the X-Plane S-TEC autopilot controls are included at the moment, and they are designed as one predefined group of controls. If you would like support for other autopilots, or the ability to add individual autopilot buttons to the Touch Bar, please open a GitHub Issue.
+
 ## Requirements
 
 - Mac with Touch Bar
-- macOS 12
+- macOS 12 or higher
 - X-Plane 11.55 or higher
 - Access to X-Plane's UDP port (default: 49000)
 - External monitor (if you are using X-Plane and XPTouchBar on the same machine)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Control [X-Plane](https://www.x-plane.com) with the Mac Touch Bar.
 
 XPTouchBar is a companion app to X-Plane which presents flight controls in the Touch Bar.
 
-XPTouchBar is completely customizable. You choose the controls that appear in the Touch Bar to complement the aircraft you're flying, and the hardware controls you have. (For example, if you don't have a throttle quadrant, put the throttle controls in the Touch Bar. If you do have a throttle quadrant, use the Touch Bar for something else).
+XPTouchBar is completely customizable. You choose the controls that appear in the Touch Bar to complement the aircraft you're flying, and the hardware controls you have. (For example, if you don't have a throttle quadrant, you could put the throttle controls in the Touch Bar. If you do have a throttle quadrant, you could put some of the other controls in the Touch Bar).
 
 You could use XPTouchBar as...
 
@@ -73,7 +73,7 @@ XPTouchBar has Touch Bar widgets for the following aircraft controls:
   - NAV2 (audio)
   - DME (audio)
   - MKR (audio)
-- Autopilot (S-TEC 55)
+- Autopilot (S-TEC 55 like)
   - HDG
   - NAV
   - APR

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,13 +73,13 @@ XPTouchBar has Touch Bar widgets for the following aircraft controls:
   - NAV2 (audio)
   - DME (audio)
   - MKR (audio)
-- Autopilot (S-TEC 55 like)
+- Autopilot
   - HDG
   - NAV
   - APR
   - REV
   - ALT
-  - VS (with +VS/-VS controls, press-and-hold them to change vertical speed quickly)
+  - VS (with +VS/-VS controls, press-and-hold to change vertical speed quickly)
   
 XPTouchBar also forwards the following X-Plane keyboard shortcuts for convenience:
 
@@ -99,7 +99,7 @@ XPTouchBar also forwards the following X-Plane keyboard shortcuts for convenienc
 | ⇧9  | Camera: 3D Cockpit       |
 | ⇧W  | Camera: Forward With HUD |
 
-**Note:** For simplicity, only the X-Plane S-TEC autopilot controls are included at the moment, and they are designed as one predefined group of controls. If you would like support for other autopilots, or the ability to add individual autopilot buttons to the Touch Bar, please open a GitHub Issue.
+**Note:** For simplicity, only the X-Plane S-TEC like autopilot controls are included at the moment, and they are designed as one predefined group of controls. If you would like support for other autopilot controls, or the ability to add individual autopilot controls to the Touch Bar, please open a GitHub Issue.
 
 ## Requirements
 


### PR DESCRIPTION
Add autopilot controls.

Design notes:

The autopilot is as involved in flying the aircraft as the throttle quadrant, therefore both are assigned to the top level of the Touch Bar for ease of access. Unfortunately there is not room in the Touch Bar for both of them at the same time, so you'll need to choose the one that you need more.

The S-TEC 55 is simple and compact enough that its set of 6 buttons (plus vertical speed adjuster) can fit in the Touch Bar with default Control Strip settings. Therefore only S-TEC controls are included in the first version of this feature. This is something that can be revisited if there is demand for other autopilots.