### PR TITLE
Refactor most dataref inputs to use commandrefs

### DIFF
--- a/XPTouchBar/DebugView.swift
+++ b/XPTouchBar/DebugView.swift
@@ -29,8 +29,7 @@ struct DebugView: View {
             Entry(dataref: Dataref.Nav2Power, value: props.nav2power),
             Entry(dataref: Dataref.AudioSelectionNav2, value: props.nav2audio),
             Entry(dataref: Dataref.AudioComSelection, value: props.comSelection),
-            Entry(dataref: Dataref.AudioDmeEnabled, value: props.dmeAudio),
-            Entry(dataref: Dataref.HideYoke, value: props.hideYoke)
+            Entry(dataref: Dataref.AudioDmeEnabled, value: props.dmeAudio)
         ].sorted(using: sortOrder)
     }
     

--- a/XPTouchBar/MyTouchBar.swift
+++ b/XPTouchBar/MyTouchBar.swift
@@ -210,80 +210,80 @@ class MyTouchBar: NSObject, NSTouchBarDelegate {
     @objc func cameraChanged(_ sender: NSPickerTouchBarItem) {
         switch sender.selectedIndex {
         case 0:
-            props.camera = .cockpit
+            props.cameraCockpit()
         case 1:
-            props.camera = .chase
+            props.cameraChase()
         case 2:
-            props.camera = .circle
+            props.cameraCircle()
         case 3:
-            props.camera = .hud
+            props.cameraHud()
         case 4:
-            props.camera = .linearSpot
+            props.cameraLinearSpot()
         case 5:
-            props.camera = .runway
+            props.cameraRunway()
         case 6:
-            props.camera = .stillSpot
+            props.cameraStillSpot()
         case 7:
-            props.camera = .tower
+            props.cameraTower()
         default:
             break
         }
     }
     
     @objc func gearChanged(_ sender: NSButton) {
-        props.gear.toggle()
+        props.toggleLandingGear()
     }
     
     @objc func parkingBrakeChanged(_ sender: NSButton) {
-        props.parkingBrake.toggle()
+        props.toggleParkingBrake()
     }
     
     @objc func beaconChanged(_ sender: NSButton) {
-        props.beaconLights.toggle()
+        props.toggleBeaconLights()
     }
     
     @objc func landingChanged(_ sender: NSButton) {
-        props.landingLights.toggle()
+        props.toggleLandingLights()
     }
     
     @objc func navigationChanged(_ sender: NSButton) {
-        props.navigationLights.toggle()
+        props.toggleNavLights()
     }
     
     @objc func taxiChanged(_ sender: NSButton) {
-        props.taxiLight.toggle()
+        props.toggleTaxiLights()
     }
     
     @objc func strobeChanged(_ sender: NSButton) {
-        props.strobeLights.toggle()
+        props.toggleStrobeLights()
     }
     
     @objc func com1Changed(_ sender: NSButton) {
-        props.com1audio.toggle()
+        props.toggleCom1Audio()
     }
     
     @objc func com2Changed(_ sender: NSButton) {
-        props.com2audio.toggle()
+        props.toggleCom2Audio()
     }
     
     @objc func nav1Changed(_ sender: NSButton) {
-        props.nav1audio.toggle()
+        props.toggleNav1Audio()
     }
     
     @objc func nav2Changed(_ sender: NSButton) {
-        props.nav2audio.toggle()
+        props.toggleNav2Audio()
     }
     
     @objc func dmeChanged(_ sender: NSButton) {
-        props.dmeAudio.toggle()
+        props.toggleDmeAudio()
     }
     
     @objc func com1MicPressed(_ sender: NSButton) {
-        props.comSelection = .com1
+        props.com1Mic()
     }
     
     @objc func com2MicPressed(_ sender: NSButton) {
-        props.comSelection = .com2
+        props.com2Mic()
     }
     
     func updateNSTouchBar(_ touchBar: NSTouchBar) {

--- a/XPTouchBar/XPTouchBarApp.swift
+++ b/XPTouchBar/XPTouchBarApp.swift
@@ -13,7 +13,7 @@ struct XPTouchBarApp: App {
                 return self.props.comSelection == .com1
             },
             set: { _ in
-                self.props.comSelection = .com1
+                self.props.com1Mic()
             })
     }
     
@@ -23,7 +23,7 @@ struct XPTouchBarApp: App {
                 return self.props.comSelection == .com2
             },
             set: { _ in
-                self.props.comSelection = .com2
+                self.props.com2Mic()
             })
     }
     
@@ -104,11 +104,12 @@ struct XPTouchBarApp: App {
             SidebarCommands()
             
             CommandMenu("Controls") {
-                Toggle("Parking Brake", isOn: $props.parkingBrake)
-                    .keyboardShortcut("B", modifiers: [])
+                Button("Parking Brake") {
+                    props.toggleParkingBrake()
+                }.keyboardShortcut("B", modifiers: [])
                 
                 Button("Landing Gear") {
-                    props.gear.toggle()
+                    props.toggleLandingGear()
                 }.keyboardShortcut("G", modifiers: [])
                 
                 Button("Show/Hide Map") {
@@ -121,7 +122,7 @@ struct XPTouchBarApp: App {
                 .keyboardShortcut("P", modifiers: [])
                 
                 Button("Show/Hide Yoke") {
-                    props.hideYoke.toggle()
+                    props.toggleYoke()
                 }
                 .keyboardShortcut("Y", modifiers: [])
                 
@@ -133,42 +134,42 @@ struct XPTouchBarApp: App {
             CommandMenu("Camera") {
                 
                 Button("Linear Spot") {
-                    self.props.camera = .linearSpot
+                    self.props.cameraLinearSpot()
                 }
                 .keyboardShortcut("1", modifiers: [.shift])
                 
                 Button("Still Spot") {
-                    self.props.camera = .stillSpot
+                    self.props.cameraStillSpot()
                 }
                 .keyboardShortcut("2", modifiers: [.shift])
                 
                 Button("Runway") {
-                    self.props.camera = .runway
+                    self.props.cameraRunway()
                 }
                 .keyboardShortcut("3", modifiers: [.shift])
                 
                 Button("Circle") {
-                    self.props.camera = .circle
+                    self.props.cameraCircle()
                 }
                 .keyboardShortcut("4", modifiers: [.shift])
                 
                 Button("Tower") {
-                    self.props.camera = .tower
+                    self.props.cameraTower()
                 }
                 .keyboardShortcut("5", modifiers: [.shift])
                 
                 Button("Chase") {
-                    self.props.camera = .chase
+                    self.props.cameraChase()
                 }
                 .keyboardShortcut("8", modifiers: [.shift])
                 
                 Button("Cockpit") {
-                    self.props.camera = .cockpit
+                    self.props.cameraCockpit()
                 }
                 .keyboardShortcut("9", modifiers: [.shift])
                 
                 Button("Forward with HUD") {
-                    self.props.camera = .hud
+                    self.props.cameraHud()
                 }
                 .keyboardShortcut("W", modifiers: [.shift])
             }
@@ -184,7 +185,9 @@ struct XPTouchBarApp: App {
     var com1radios: some View {
         Group {
             Toggle("COM1 Power", isOn: $props.com1power)
-            Toggle("COM1 Audio", isOn: $props.com1audio)
+            Button("COM1 Audio") {
+                props.toggleCom1Audio()
+            }
             Toggle("COM1 Mic", isOn: com1Mic)
         }
     }
@@ -192,7 +195,9 @@ struct XPTouchBarApp: App {
     var com2radios: some View {
         Group {
             Toggle("COM2 Power", isOn: $props.com2power)
-            Toggle("COM2 Audio", isOn: $props.com2audio)
+            Button("COM2 Audio") {
+                props.toggleCom2Audio()
+            }
             Toggle("COM2 Mic", isOn: com2Mic)
         }
     }
@@ -200,14 +205,18 @@ struct XPTouchBarApp: App {
     var nav1radios: some View {
         Group {
             Toggle("NAV1 Power", isOn: $props.nav1power)
-            Toggle("NAV1 Audio", isOn: $props.nav1audio)
+            Button("NAV1 Audio") {
+                props.toggleNav1Audio()
+            }
         }
     }
     
     var nav2radios: some View {
         Group {
             Toggle("NAV2 Power", isOn: $props.nav2power)
-            Toggle("NAV2 Audio", isOn: $props.nav2audio)
+            Button("NAV2 Audio") {
+                props.toggleNav2Audio()
+            }
         }
     }
     
@@ -233,17 +242,29 @@ struct XPTouchBarApp: App {
             Divider()
             navRadios
             Divider()
-            Toggle("DME Audio", isOn: $props.dmeAudio)
+            Button("DME Audio") {
+                props.toggleDmeAudio()
+            }
         }
     }
     
     var lights: some View {
         Menu("Lights") {
-            Toggle("Beacon", isOn: $props.beaconLights)
-            Toggle("Landing", isOn: $props.landingLights)
-            Toggle("Nav", isOn: $props.navigationLights)
-            Toggle("Strobe", isOn: $props.strobeLights)
-            Toggle("Taxi", isOn: $props.taxiLight)
+            Button("Beacon") {
+                props.toggleBeaconLights()
+            }
+            Button("Landing") {
+                props.toggleLandingLights()
+            }
+            Button("Nav") {
+                props.toggleNavLights()
+            }
+            Button("Strobe") {
+                props.toggleStrobeLights()
+            }
+            Button("Taxi") {
+                props.toggleTaxiLights()
+            }
         }
     }
 }

--- a/XPTouchBar/XPlaneConnector/Command.swift
+++ b/XPTouchBar/XPlaneConnector/Command.swift
@@ -4,6 +4,53 @@ import Foundation
 enum Command {
     /// Toggle the map window
     case MapShowCurrent
+    
+    case LandingGearToggle
+    
+    case BeaconLightsToggle
+    
+    case LandingLightsToggle
+    
+    case NavLightsToggle
+    
+    case StrobeLightsToggle
+    
+    case TaxiLightsToggle
+    
+    case ToggleYoke
+    
+    case MonitorAudioCom1
+    
+    case MonitorAudioCom2
+    
+    case MonitorAudioNav1
+    
+    case MonitorAudioNav2
+    
+    case MonitorAudioDme
+    
+    case TransmitAudioCom1
+    
+    case TransmitAudioCom2
+    
+    case LinearSpot
+    
+    case StillSpot
+    
+    case Runway
+    
+    case Tower
+    
+    case Chase
+    
+    case Circle
+    
+    case ThreeDCockpit
+    
+    case ForwardWithHud
+    
+    /// Used as a proxy for the parking brake
+    case BrakesToggleMax
 }
 
 extension Command: CustomStringConvertible {
@@ -11,6 +58,52 @@ extension Command: CustomStringConvertible {
         switch self {
         case .MapShowCurrent:
             return "sim/map/show_current"
+        case .LandingGearToggle:
+            return "sim/flight_controls/landing_gear_toggle"
+        case .BeaconLightsToggle:
+            return "sim/lights/beacon_lights_toggle"
+        case .LandingLightsToggle:
+            return "sim/lights/landing_lights_toggle"
+        case .NavLightsToggle:
+            return "sim/lights/nav_lights_toggle"
+        case .StrobeLightsToggle:
+            return "sim/lights/strobe_lights_toggle"
+        case .TaxiLightsToggle:
+            return "sim/lights/taxi_lights_toggle"
+        case .ToggleYoke:
+            return "sim/operation/toggle_yoke"
+        case .MonitorAudioCom1:
+            return "sim/audio_panel/monitor_audio_com1"
+        case .MonitorAudioCom2:
+            return "sim/audio_panel/monitor_audio_com2"
+        case .MonitorAudioNav1:
+            return "sim/audio_panel/monitor_audio_nav1"
+        case .MonitorAudioNav2:
+            return "sim/audio_panel/monitor_audio_nav2"
+        case .MonitorAudioDme:
+            return "sim/audio_panel/monitor_audio_dme"
+        case .LinearSpot:
+            return "sim/view/linear_spot"
+        case .StillSpot:
+            return "sim/view/still_spot"
+        case .Runway:
+            return "sim/view/runway"
+        case .Tower:
+            return "sim/view/tower"
+        case .Chase:
+            return "sim/view/chase"
+        case .Circle:
+            return "sim/view/circle"
+        case .ThreeDCockpit:
+            return "sim/view/3d_cockpit_cmnd_look"
+        case .ForwardWithHud:
+            return "sim/view/forward_with_hud"
+        case .TransmitAudioCom1:
+            return "sim/audio_panel/transmit_audio_com1"
+        case .TransmitAudioCom2:
+            return "sim/audio_panel/transmit_audio_com2"
+        case .BrakesToggleMax:
+            return "sim/flight_controls/brakes_toggle_max"
         }
     }
 }

--- a/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
+++ b/XPTouchBar/XPlaneConnector/XPlaneConnector.swift
@@ -31,20 +31,6 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
-    @Published var gear: Gear = .down {
-        didSet {
-            let dref = DREF(dataref: .GearHandleDown, value: gear.floatValue)
-            self.send(dref)
-        }
-    }
-    
-    @Published var parkingBrake: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .ParkingBrakeRatio, value: parkingBrake.floatValue)
-            self.send(dref)
-        }
-    }
-    
     @Published var speedbrake: Float = 0 {
         didSet {
             let dref = DREF(dataref: .SpeedbrakeRatio, value: speedbrake)
@@ -59,48 +45,22 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
-    @Published var landingLights: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .LandingLightsOn, value: landingLights.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var parkingBrake: Bool = true
     
-    @Published var strobeLights: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .StrobeLightsOn, value: strobeLights.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var gear: Gear = .down
     
-    @Published var taxiLight: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .TaxiLightOn, value: taxiLight.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var landingLights: Bool = true
     
-    @Published var beaconLights: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .BeaconOn, value: beaconLights.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var strobeLights: Bool = true
     
-    @Published var navigationLights: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .NavigationLightsOn, value: navigationLights.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var taxiLight: Bool = true
     
-    @Published var hideYoke: Bool = false {
-        didSet {
-            let dref = DREF(dataref: .HideYoke, value: hideYoke.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var beaconLights: Bool = true
     
+    @Published private(set) var navigationLights: Bool = true
+    
+    @Published private(set) var camera: Camera = .cockpit
+        
     @Published var com1power: Bool = true {
         didSet {
             let dref = DREF(dataref: .Com1Power, value: com1power.floatValue)
@@ -108,12 +68,7 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
-    @Published var com1audio: Bool = true {
-        didSet {
-            let dref = DREF(dataref: .AudioSelectionCom1, value: com1audio.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var com1audio: Bool = true
     
     @Published var com2power: Bool = true {
         didSet {
@@ -122,12 +77,7 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
-    @Published var com2audio: Bool = false {
-        didSet {
-            let dref = DREF(dataref: .AudioSelectionCom2, value: com2audio.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var com2audio: Bool = false
     
     @Published var nav1power: Bool = true {
         didSet {
@@ -136,12 +86,7 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
-    @Published var nav1audio: Bool = false {
-        didSet {
-            let dref = DREF(dataref: .AudioSelectionNav1, value: nav1audio.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var nav1audio: Bool = false
     
     @Published var nav2power: Bool = true {
         didSet {
@@ -150,23 +95,14 @@ class XPlaneConnector: ObservableObject {
         }
     }
     
-    @Published var nav2audio: Bool = false {
-        didSet {
-            let dref = DREF(dataref: .AudioSelectionNav2, value: nav2audio.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var nav2audio: Bool = false
     
-    @Published var dmeAudio: Bool = false {
-        didSet {
-            let dref = DREF(dataref: .AudioDmeEnabled, value: dmeAudio.floatValue)
-            self.send(dref)
-        }
-    }
+    @Published private(set) var dmeAudio: Bool = false
     
-    @Published var comSelection: ComSelection = .com1 {
+    @Published private(set) var comSelection: ComSelection = .com1 {
         didSet {
             // Set the corresponding COM receive button states
+            // TODO remove once receiving from RREF subscription
             switch comSelection {
             case .com1:
                 self.com1audio = true
@@ -175,16 +111,6 @@ class XPlaneConnector: ObservableObject {
                 self.com1audio = false
                 self.com2audio = true
             }
-            
-            let dref = DREF(dataref: .AudioComSelection, value: comSelection.floatValue)
-            self.send(dref)
-        }
-    }
-    
-    @Published var camera: Camera = .cockpit {
-        didSet {
-            let dref = DREF(dataref: .ViewType, value: camera.floatValue)
-            self.send(dref)
         }
     }
     
@@ -239,6 +165,167 @@ class XPlaneConnector: ObservableObject {
     func toggleMap() {
         let cmnd = CMND(command: .MapShowCurrent)
         self.send(cmnd)
+    }
+    
+    func toggleYoke() {
+        let cmnd = CMND(command: .ToggleYoke)
+        self.send(cmnd)
+    }
+    
+    func toggleCom1Audio() {
+        let cmnd = CMND(command: .MonitorAudioCom1)
+        self.send(cmnd)
+        
+        self.com1audio.toggle()
+    }
+    
+    func com1Mic() {
+        let cmnd = CMND(command: .TransmitAudioCom1)
+        self.send(cmnd)
+        
+        self.comSelection = .com1
+    }
+    
+    func toggleCom2Audio() {
+        let cmnd = CMND(command: .MonitorAudioCom2)
+        self.send(cmnd)
+        
+        self.com2audio.toggle()
+    }
+    
+    func com2Mic() {
+        let cmnd = CMND(command: .TransmitAudioCom2)
+        self.send(cmnd)
+        
+        self.comSelection = .com2
+    }
+    
+    func toggleNav1Audio() {
+        let cmnd = CMND(command: .MonitorAudioNav1)
+        self.send(cmnd)
+        
+        self.nav1audio.toggle()
+    }
+    
+    func toggleNav2Audio() {
+        let cmnd = CMND(command: .MonitorAudioNav2)
+        self.send(cmnd)
+        
+        self.nav2audio.toggle()
+    }
+    
+    func toggleDmeAudio() {
+        let cmnd = CMND(command: .MonitorAudioDme)
+        self.send(cmnd)
+        
+        self.dmeAudio.toggle()
+    }
+    
+    func toggleLandingGear() {
+        let cmnd = CMND(command: .LandingGearToggle)
+        self.send(cmnd)
+        
+        // Update local state
+        // TODO remove once using RREF subscriptions
+        self.gear.toggle()
+    }
+    
+    func toggleParkingBrake() {
+        let cmnd = CMND(command: .BrakesToggleMax)
+        self.send(cmnd)
+        
+        self.parkingBrake.toggle()
+    }
+    
+    func toggleBeaconLights() {
+        let cmnd = CMND(command: .BeaconLightsToggle)
+        self.send(cmnd)
+        
+        self.beaconLights.toggle()
+    }
+    
+    func toggleLandingLights() {
+        let cmnd = CMND(command: .LandingLightsToggle)
+        self.send(cmnd)
+        
+        self.landingLights.toggle()
+    }
+    
+    func toggleNavLights() {
+        let cmnd = CMND(command: .NavLightsToggle)
+        self.send(cmnd)
+        
+        self.navigationLights.toggle()
+    }
+    
+    func toggleStrobeLights() {
+        let cmnd = CMND(command: .StrobeLightsToggle)
+        self.send(cmnd)
+        
+        self.strobeLights.toggle()
+    }
+    
+    func toggleTaxiLights() {
+        let cmnd = CMND(command: .TaxiLightsToggle)
+        self.send(cmnd)
+        
+        self.taxiLight.toggle()
+    }
+    
+    func cameraChase() {
+        let cmnd = CMND(command: .Chase)
+        self.send(cmnd)
+        
+        self.camera = .chase
+    }
+    
+    func cameraCircle() {
+        let cmnd = CMND(command: .Circle)
+        self.send(cmnd)
+        
+        self.camera = .circle
+    }
+    
+    func cameraCockpit() {
+        let cmnd = CMND(command: .ThreeDCockpit)
+        self.send(cmnd)
+        
+        self.camera = .cockpit
+    }
+    
+    func cameraHud() {
+        let cmnd = CMND(command: .ForwardWithHud)
+        self.send(cmnd)
+        
+        self.camera = .hud
+    }
+    
+    func cameraLinearSpot() {
+        let cmnd = CMND(command: .LinearSpot)
+        self.send(cmnd)
+        
+        self.camera = .linearSpot
+    }
+    
+    func cameraStillSpot() {
+        let cmnd = CMND(command: .StillSpot)
+        self.send(cmnd)
+        
+        self.camera = .stillSpot
+    }
+    
+    func cameraRunway() {
+        let cmnd = CMND(command: .Runway)
+        self.send(cmnd)
+        
+        self.camera = .runway
+    }
+    
+    func cameraTower() {
+        let cmnd = CMND(command: .Tower)
+        self.send(cmnd)
+        
+        self.camera = .tower
     }
     
     private func restart() {


### PR DESCRIPTION
Refactor most inputs to use commandrefs instead of writing to datarefs (which is no longer best practice).

If it becomes possible to receive inputs from X-Plane via UDP, we will then use read-only datarefs to populate the visible state of the relevant buttons (e.g. on/off). The data flow will then become

push button -> send CMND -> X-Plane -> receive RREF update (with new button state) -> update UI